### PR TITLE
Color Legends, Seq Position Filtering, Mock Data BugFix

### DIFF
--- a/src/components/PatentVisualizer/ColorSquare.js
+++ b/src/components/PatentVisualizer/ColorSquare.js
@@ -1,0 +1,13 @@
+const ColorSquare = (props) => (
+    <div style={{
+        position: 'absolute',
+        right: 20,
+        top: 10,
+        height: 20,
+        width: 20,
+        clear: 'both',
+        backgroundColor: props.color || 'green' 
+    }}/>
+);
+
+export default ColorSquare;

--- a/src/components/PatentVisualizer/PatentVisualizer.js
+++ b/src/components/PatentVisualizer/PatentVisualizer.js
@@ -29,11 +29,18 @@ const PatentVisualizer = () => {
 
     // Assignees Effect
     const [assignees, setAssignees] = useState({});
+    const [sequenceRange, setSequenceRange] = useState({ min: 1, max: 100 });
     useEffect(() => {
-        setData(_dataRef.current.filter(patentData => {
-            return assignees[patentData[KEYS.assignee]]
-        }))
-    }, [assignees]);
+        setData(_dataRef.current
+            .filter(patentData => {
+                return assignees[patentData[KEYS.assignee]]
+            })
+            .filter((patentData) => {
+                return sequenceRange.min <= patentData[KEYS.sequencePosition] <= sequenceRange.max;
+            })
+        );
+    }, [assignees, sequenceRange]);
+    
 
     const asyncFetch = () => {
         Promise.resolve(mock)
@@ -100,10 +107,19 @@ const PatentVisualizer = () => {
             [name]: e.target.checked
         });
     }
+
+    const onSequenceRangeFilterChange = (sequenceRange) => {
+        setSequenceRange({
+            ...sequenceRange
+        });
+    }
     return (
         [
             <Layout>
-                <PatentVisualizerSidebar assignees={assignees} colorKeys={colorKeys} onAssigneeFilterChange={onAssigneeFilterChange} />
+                <PatentVisualizerSidebar assignees={assignees} colorKeys={colorKeys} sequenceLength={data.length}
+                    onAssigneeFilterChange={onAssigneeFilterChange} 
+                    onSequenceRangeFilterChange={onSequenceRangeFilterChange}
+                />
                 <Layout style={{ padding: '24px' }}>
                     <Heatmap onEvent={onEvent} {...config} />
                 </Layout>

--- a/src/components/PatentVisualizer/PatentVisualizer.js
+++ b/src/components/PatentVisualizer/PatentVisualizer.js
@@ -53,24 +53,27 @@ const PatentVisualizer = () => {
                 console.log('fetch data failed', error);
             });
     };
+    const gridStyles = { 
+        grid: {
+            line: {
+                style: {
+                    stroke: 'black',
+                    lineWidth: 1,
+                    strokeOpacity: 0.3,
+                    cursor: 'pointer'
+                }
+            }
+        }
+    }
+
     const config = {
         width: 650,
         height: 500,
         autoFit: true,
         data: data,
         xField: KEYS.sequencePosition,
-        axis: {
-            grid: {
-                line: {
-                    style: {
-                        stroke: 'black',
-                        lineWidth: 1,
-                        strokeOpacity: 0.1,
-                        cursor: 'pointer'
-                    }
-                }
-            }
-        },
+        xAxis: gridStyles,
+        yAxis: gridStyles,
         yField: KEYS.patentNumber,
         colorField: KEYS.assignee,
         color: (assignee) => {
@@ -100,7 +103,7 @@ const PatentVisualizer = () => {
     return (
         [
             <Layout>
-                <PatentVisualizerSidebar assignees={assignees} onAssigneeFilterChange={onAssigneeFilterChange} />
+                <PatentVisualizerSidebar assignees={assignees} colorKeys={colorKeys} onAssigneeFilterChange={onAssigneeFilterChange} />
                 <Layout style={{ padding: '24px' }}>
                     <Heatmap onEvent={onEvent} {...config} />
                 </Layout>

--- a/src/components/PatentVisualizer/PatentVisualizerSidebar.js
+++ b/src/components/PatentVisualizer/PatentVisualizerSidebar.js
@@ -1,4 +1,3 @@
-import React, { useState, useEffect } from 'react';
 import { Layout, Menu, Checkbox, Slider, InputNumber } from 'antd';
 import 'antd/dist/antd.css';
 import { UserOutlined } from '@ant-design/icons';
@@ -19,22 +18,38 @@ const renderCheckboxList = (filterObject, onChange, colorKeys) => {
     });
 }
 
-const PatentVisualizerSidebar = (props) => {
-    const { sequenceLength } = props;
-    const [ minValue, setMinValue ] = useState(1);
-    const [ maxValue, setMaxValue ] = useState(sequenceLength);
-    useEffect(() => {
-        // If maxValue is not defined or 0 we want to make sure the full range is selected
-        // This happens on first render when component have not sent the data to props.sequenceLength
-        if(!maxValue) {
-            setMaxValue(sequenceLength);
-        }
-    }, [sequenceLength, maxValue]);
+const renderInputNumber = (value, label, onChange) => {
+    return (
+        <div key={'inputNumber' + label} style={{ 
+            display: 'flex',
+            margin: 'auto',
+            justifyContent: 'center',
+            alignItems: 'baseline'
+        }}>
+            <span>{label}</span>
+            <InputNumber
+                style={{ margin: '0 16px', width: '40%' }}
+                value={value}
+                onChange={onChange}
+            />
+        </div>
+    );
+}
+const renderSequenceFilter = (min, max, length, onSequenceRangeFilterChange) => {
+    return (
+        [
+            <Slider key={'slider1'} style={{ width: '80%', margin: 'auto', padding: '25px 0px' }} range value={[ min, max ]} max={length}
+                onChange={([ minSlider, maxSlider ]) => onSequenceRangeFilterChange({ min: minSlider, max: maxSlider })} 
+            />,
+            renderInputNumber(min, StringManager.get('minLabel'), (min) => onSequenceRangeFilterChange({ min, max })),
+            renderInputNumber(max, StringManager.get('maxLabel'), (max) => onSequenceRangeFilterChange({ min, max }))
+        ]
+    );
+}
 
-    // Notify parent component that the sequence range has changed
-    // useEffect(() => {
-    //     onSequenceRangeFilterChange({ min: minValue, max: maxValue });
-    // }, [minValue, maxValue, onSequenceRangeFilterChange]);
+const PatentVisualizerSidebar = (props) => {
+    const { onSequenceRangeFilterChange, sequenceRange } = props;
+    const { min, max, length } = sequenceRange;
 
     return (
         <Sider width={'15%'} className="site-layout-background">
@@ -47,44 +62,8 @@ const PatentVisualizerSidebar = (props) => {
                 <SubMenu key="sub1" icon={<UserOutlined />} title={StringManager.get('filterByAssignee')}>
                     {renderCheckboxList(props.assignees, props.onAssigneeFilterChange, props.colorKeys)}
                 </SubMenu>
-                <SubMenu key="sub2" icon={<UserOutlined />} title="Filter By Sequence Position">
-                    <Slider style={{ width: '80%', margin: 'auto', padding: '25px 0px' }} range value={[ minValue, maxValue ]} max={props.sequenceLength} onChange={(data) => {
-                        setMinValue(data[0]);
-                        setMaxValue(data[1]);
-                    }} />
-                    <div style={{ 
-                        display: 'flex',
-                        margin: 'auto',
-                        justifyContent: 'center',
-                        alignItems: 'baseline'
-                    }}>
-                        <span>Min:</span>
-                        <InputNumber
-                            min={1}
-                            max={maxValue}
-                            style={{ margin: '0 16px', width: '40%' }}
-                            value={minValue}
-                            onChange={(min) => {
-                                setMinValue(min);
-                                console.log('min', min);
-                            }}
-                        />
-                    </div>
-                    <div style={{ 
-                        display: 'flex',
-                        margin: 'auto',
-                        justifyContent: 'center',
-                        alignItems: 'baseline'
-                    }}>
-                        <span>Max:</span>
-                        <InputNumber
-                            min={minValue}
-                            max={props.sequenceLength}
-                            style={{ margin: '0 16px', width: '40%' }}
-                            value={maxValue}
-                            onChange={(max) => setMaxValue(max)}
-                        />
-                    </div>
+                <SubMenu key="sub2" icon={<UserOutlined />} title={StringManager.get('filterBySequencePosition')}>
+                    {renderSequenceFilter(min, max, length, onSequenceRangeFilterChange)}
                 </SubMenu>
             </Menu>
         </Sider>

--- a/src/components/PatentVisualizer/PatentVisualizerSidebar.js
+++ b/src/components/PatentVisualizer/PatentVisualizerSidebar.js
@@ -1,4 +1,5 @@
-import { Layout, Menu, Checkbox } from 'antd';
+import React, { useState, useEffect } from 'react';
+import { Layout, Menu, Checkbox, Slider, InputNumber } from 'antd';
 import 'antd/dist/antd.css';
 import { UserOutlined } from '@ant-design/icons';
 import StringManager from '../../utils/StringManager';
@@ -19,16 +20,71 @@ const renderCheckboxList = (filterObject, onChange, colorKeys) => {
 }
 
 const PatentVisualizerSidebar = (props) => {
+    const { sequenceLength } = props;
+    const [ minValue, setMinValue ] = useState(1);
+    const [ maxValue, setMaxValue ] = useState(sequenceLength);
+    useEffect(() => {
+        // If maxValue is not defined or 0 we want to make sure the full range is selected
+        // This happens on first render when component have not sent the data to props.sequenceLength
+        if(!maxValue) {
+            setMaxValue(sequenceLength);
+        }
+    }, [sequenceLength, maxValue]);
+
+    // Notify parent component that the sequence range has changed
+    // useEffect(() => {
+    //     onSequenceRangeFilterChange({ min: minValue, max: maxValue });
+    // }, [minValue, maxValue, onSequenceRangeFilterChange]);
+
     return (
         <Sider width={'15%'} className="site-layout-background">
             <Menu
                 mode="inline"
                 defaultSelectedKeys={['1']}
-                defaultOpenKeys={['sub1']}
+                defaultOpenKeys={['sub1', 'sub2']}
                 style={{ height: '100%', borderRight: 0 }}
             >
                 <SubMenu key="sub1" icon={<UserOutlined />} title={StringManager.get('filterByAssignee')}>
                     {renderCheckboxList(props.assignees, props.onAssigneeFilterChange, props.colorKeys)}
+                </SubMenu>
+                <SubMenu key="sub2" icon={<UserOutlined />} title="Filter By Sequence Position">
+                    <Slider style={{ width: '80%', margin: 'auto', padding: '25px 0px' }} range value={[ minValue, maxValue ]} max={props.sequenceLength} onChange={(data) => {
+                        setMinValue(data[0]);
+                        setMaxValue(data[1]);
+                    }} />
+                    <div style={{ 
+                        display: 'flex',
+                        margin: 'auto',
+                        justifyContent: 'center',
+                        alignItems: 'baseline'
+                    }}>
+                        <span>Min:</span>
+                        <InputNumber
+                            min={1}
+                            max={maxValue}
+                            style={{ margin: '0 16px', width: '40%' }}
+                            value={minValue}
+                            onChange={(min) => {
+                                setMinValue(min);
+                                console.log('min', min);
+                            }}
+                        />
+                    </div>
+                    <div style={{ 
+                        display: 'flex',
+                        margin: 'auto',
+                        justifyContent: 'center',
+                        alignItems: 'baseline'
+                    }}>
+                        <span>Max:</span>
+                        <InputNumber
+                            min={minValue}
+                            max={props.sequenceLength}
+                            style={{ margin: '0 16px', width: '40%' }}
+                            value={maxValue}
+                            onChange={(max) => setMaxValue(max)}
+                        />
+                    </div>
                 </SubMenu>
             </Menu>
         </Sider>

--- a/src/components/PatentVisualizer/PatentVisualizerSidebar.js
+++ b/src/components/PatentVisualizer/PatentVisualizerSidebar.js
@@ -2,14 +2,17 @@ import { Layout, Menu, Checkbox } from 'antd';
 import 'antd/dist/antd.css';
 import { UserOutlined } from '@ant-design/icons';
 import StringManager from '../../utils/StringManager';
+import ColorSquare from './ColorSquare';
 const { SubMenu } = Menu;
 const { Sider } = Layout;
 
-const renderCheckboxList = (filterObject, onChange) => {
+const renderCheckboxList = (filterObject, onChange, colorKeys) => {
     return Object.keys(filterObject).map((key, index) => {
         return (
             <Menu.Item key={index}>
-                <Checkbox onChange={(e) => onChange(e, key)} checked={filterObject[key]}>{key}</Checkbox>
+                <Checkbox onChange={(e) => onChange(e, key)} checked={filterObject[key]}>
+                    {key} {colorKeys[key] && <ColorSquare color={colorKeys[key]} />}
+                </Checkbox>
             </Menu.Item>
         )
     });
@@ -25,7 +28,7 @@ const PatentVisualizerSidebar = (props) => {
                 style={{ height: '100%', borderRight: 0 }}
             >
                 <SubMenu key="sub1" icon={<UserOutlined />} title={StringManager.get('filterByAssignee')}>
-                    {renderCheckboxList(props.assignees, props.onAssigneeFilterChange)}
+                    {renderCheckboxList(props.assignees, props.onAssigneeFilterChange, props.colorKeys)}
                 </SubMenu>
             </Menu>
         </Sider>

--- a/src/strings.js
+++ b/src/strings.js
@@ -5,7 +5,10 @@ const strings = {
     selectEpitope: 'Sequence',
     selectProtein: 'Protein Name',
     appOwnershipFooter: 'Patent Visualization App - Created by The Avengers',
-    filterByAssignee: 'Filter By Assignee'
+    filterByAssignee: 'Filter By Assignee',
+    filterBySequencePosition: 'Filter By Sequence Position',
+    minLabel: 'Min:',
+    maxLabel: 'Max:'
 }
 
 export default Object.freeze(strings);

--- a/src/utils/mockResults.js
+++ b/src/utils/mockResults.js
@@ -1,11 +1,12 @@
+const MAX_SEQ_LENGTH = 500;
 const getRandomPatents = (size) => {
     const randomPatents = [];
     const assignedIds = {};
-    for(let i = 0; i < 500; i++) {
+    for(let i = 0; i < size; i++) {
         const patentIds = ['1134992', '1134993', '1134994', '1134995', '1134996', '1134997', '1134998', '2134992', '3134992'];
         const asignees = ['Pfizer', 'Amgen Inc', 'Regeneron Pharmaceuticals'];
         const randomPatent = patentIds[Math.floor(Math.random() * patentIds.length)];
-        const randomResidue = Math.floor(Math.random() * 100) + 1;
+        const randomResidue = Math.floor(Math.random() * MAX_SEQ_LENGTH) + 1;
         let randomAssignee; 
         if(assignedIds[randomPatent]) {
             randomAssignee = assignedIds[randomPatent];
@@ -15,7 +16,7 @@ const getRandomPatents = (size) => {
         }
         randomPatents[i] = {
             'Patent Number': randomPatent,
-            'Sequence Position': randomResidue,
+            'Sequence Position': randomResidue.toString(),
             'Assignee': randomAssignee
         }
     }
@@ -25,11 +26,17 @@ const getRandomPatents = (size) => {
 }
 
 
-const mockResults = getRandomPatents(500).sort((a, b) => {
+const mockResults = getRandomPatents(80).sort((a, b) => {
     if(parseInt(a['Sequence Position']) < parseInt(b['Sequence Position'])) {
         return -1;
-    } else if (parseInt(b['Sequence Position']) > parseInt(a['Sequence Position'])) {
+    } else if (parseInt(a['Sequence Position']) > parseInt(b['Sequence Position'])) {
         return 1;
+    } else {
+        if(parseInt(a['Patent Number']) < parseInt(b['Patent Number'])) {
+            return -1;
+        } else if (parseInt(a['Patent Number']) > parseInt(b['Patent Number'])) {
+            return 1;
+        }
     }
 
     return 0;


### PR DESCRIPTION
#### JIRA LINK ####

https://patent-visualization.atlassian.net/browse/PSV-87
https://patent-visualization.atlassian.net/browse/PSV-84
https://patent-visualization.atlassian.net/browse/PSV-83

#### CHANGES ####

- 'Bug Fix': I had a mini heart attack when I realised that the chart was showing the data in incorrect positions (seq position 1 was maybe placed in position 3 in the chart). Spent a lot of time figuring out what was wrong. Luckily it was a bug in the sorting logic and the data format of the sequence position (needs to be string instead of number)

- Added color legend for assignees. Legend overlaps name of assignee if name is too long. Spent some time trying to fix this with the lovely extra containers ant design includes when you use their components and was not able to make it work. Filed a bug to fix this later: https://patent-visualization.atlassian.net/browse/PSV-85

- Added seq position filtering by adding a slider and a min/max numeric input fields.  





#### MANDATORY GIF ####
![](https://media.giphy.com/media/f7kS7CBHbjL6kWS29W/giphy.gif)
