### PR TITLE
Fix visualization and add amino acid sequence info

### DIFF
--- a/src/components/PatentVisualizer/PatentVisualizerSidebar.js
+++ b/src/components/PatentVisualizer/PatentVisualizerSidebar.js
@@ -14,7 +14,7 @@ const renderCheckboxList = (filterObject, onChange, colorKeys) => {
                     {key} {colorKeys[key] && <ColorSquare color={colorKeys[key]} />}
                 </Checkbox>
             </Menu.Item>
-        )
+        );
     });
 }
 
@@ -65,6 +65,11 @@ const PatentVisualizerSidebar = (props) => {
                 <SubMenu key="sub2" icon={<UserOutlined />} title={StringManager.get('filterBySequencePosition')}>
                     {renderSequenceFilter(min, max, length, onSequenceRangeFilterChange)}
                 </SubMenu>
+                <Menu.Item>
+                    <Checkbox onChange={props.toggleBaseline} checked={props.showBaseline}>
+                        {StringManager.get('showAminoSequence')}
+                    </Checkbox>
+                </Menu.Item>
             </Menu>
         </Sider>
     );

--- a/src/strings.js
+++ b/src/strings.js
@@ -8,7 +8,8 @@ const strings = {
     filterByAssignee: 'Filter By Assignee',
     filterBySequencePosition: 'Filter By Sequence Position',
     minLabel: 'Min:',
-    maxLabel: 'Max:'
+    maxLabel: 'Max:',
+    showAminoSequence: 'Show Amino Acid Sequence'
 }
 
 export default Object.freeze(strings);

--- a/src/utils/mockResults.js
+++ b/src/utils/mockResults.js
@@ -5,8 +5,10 @@ const getRandomPatents = (size) => {
     for(let i = 0; i < size; i++) {
         const patentIds = ['1134992', '1134993', '1134994', '1134995', '1134996', '1134997', '1134998', '2134992', '3134992'];
         const asignees = ['Pfizer', 'Amgen Inc', 'Regeneron Pharmaceuticals'];
+        const amino = ['A', 'R', 'N', 'D'];
         const randomPatent = patentIds[Math.floor(Math.random() * patentIds.length)];
         const randomResidue = Math.floor(Math.random() * MAX_SEQ_LENGTH) + 1;
+        const randomAmino = amino[Math.floor(Math.random() * amino.length)];
         let randomAssignee; 
         if(assignedIds[randomPatent]) {
             randomAssignee = assignedIds[randomPatent];
@@ -17,7 +19,9 @@ const getRandomPatents = (size) => {
         randomPatents[i] = {
             'Patent Number': randomPatent,
             'Sequence Position': randomResidue.toString(),
-            'Assignee': randomAssignee
+            'Assignee': randomAssignee,
+            'Claimed': true,
+            'Amino Acid': randomAmino
         }
     }
 
@@ -25,13 +29,38 @@ const getRandomPatents = (size) => {
     return randomPatents;
 }
 
+/* 
+ * The current heatmap component does not have a simple way to show data the way we want it where we want the full table of sequences from 0 - n and
+ * only paint the items that are present. Previously we had that but the data points were incorrect as it creates a cumulative results based on previous points for that
+ * patent. The one way I was able to make the chart show correct data points was the following:
+ * 1) Items need to be filtered by Sequence Position
+ * 2) Sequence Position needs to be a String (making it a number will create the cumulative logic and return incorrect points)
+ * 3) One patent should have the entire sequence to make the chart show ALL entries (else it would only show only our data points so { patentId: 2, claimedResidue: 3 }, { patentId: 2, claimedResidue: 7 })
+ *    the chart will only show 3 and 7 in the X axis not 1, 2, 3, 4, 5, 6, 7 with only 2 and 7 painted.
+ * 
+ * WORKAROUND: We add the base sequence as a patent at the bottom of the chart. This way we will have an empty patent with every data point. We leverage this and we will use it to show the amino acid sequence
+*/
+let baseline = [];
+for (let i = 1; i <= MAX_SEQ_LENGTH; i++) {
+    const amino = ['A', 'R', 'N', 'D'];
+    const randomAmino = amino[Math.floor(Math.random() * amino.length)];
+    baseline.push({
+        'Patent Number': 'Sequence',
+        'Assignee': 'Sequence',
+        'Sequence Position': i.toString(),
+        'Amino Acid': randomAmino
+    })
+}
 
-const mockResults = getRandomPatents(80).sort((a, b) => {
+const mockResults = getRandomPatents(80).concat(baseline).sort((a, b) => {
     if(parseInt(a['Sequence Position']) < parseInt(b['Sequence Position'])) {
         return -1;
     } else if (parseInt(a['Sequence Position']) > parseInt(b['Sequence Position'])) {
         return 1;
     } else {
+        if (a['Patent Number'] === 'Sequence') {
+            return -1;
+        }
         if(parseInt(a['Patent Number']) < parseInt(b['Patent Number'])) {
             return -1;
         } else if (parseInt(a['Patent Number']) > parseInt(b['Patent Number'])) {


### PR DESCRIPTION
#### JIRA LINK ####

- https://patent-visualization.atlassian.net/browse/PSV-87
- https://patent-visualization.atlassian.net/browse/PSV-89

#### CHANGES ####

- Fixed a bug where the full sequence was not being displayed only the claimed residues. This heatmap component is really tricky so had to go through some workarounds and be really specific in the way we structure its input data. When we have real data we will need to sync to make sure data is being transformed that way from the BE

- See the comment in mockResults for more details but essentially I had to add the full sequence length as data in order to show the entire thing. I leveraged that limitation to use it to show the amino acid sequence at the bottom of the chart which is something Raquel wanted 😉 

- Added a toggle for showing the amino sequence

**Things not included/pending in the PR:** 

- Tooltip hover on the sequence row is really ugly. Ideally we can add details of each amino acid there or we can potentially disable it altogether. Low priority right now imo.

- Toggling the amino acid sequence on a 500+ sequence range will make the letters black blurry dots. Not sure what is the best way to go around that for now I left the default toggle off so user would only toggle it on when analysing 30-50 positions

#### DETAILS ####

![](https://user-images.githubusercontent.com/30555119/112858888-4f904280-9080-11eb-8de2-ee90a8e2bf31.png)






#### MANDATORY GIF ####
![](https://media.giphy.com/media/TW97tDnbvH7FEwEEOx/giphy.gif)
