### PR TITLE
fix slider bug when adding manual seq

### DIFF
--- a/src/components/PatentVisualizer/PatentVisualizer.js
+++ b/src/components/PatentVisualizer/PatentVisualizer.js
@@ -283,6 +283,10 @@ const PatentVisualizer = props => {
         const newDataset = sortDataset(data.concat(newSequence));
         setData(newDataset);
         _dataRef.current = newDataset;
+        // Make sure the slider updates to the maximum length if this sequence is the largest
+        if (newSequence.length > sequenceRange.length) {
+            setSequenceRange({ ...sequenceRange, length: newSequence.length });
+        }
 
         const isSeqDefined = manualSequenceList.some((elem) => elem.name === name);
         if (!isSeqDefined) {


### PR DESCRIPTION
#### JIRA LINK ####

- None. bug

#### CHANGES ####

- Simple if check to see if the manual sequence is larger than the previous largest to update slider

(note that the max length mark in slider is 692 after adding pcsk9) 
Thanks @kaliweh for catching this. 
![](https://user-images.githubusercontent.com/30555119/116001155-001e3300-a5a8-11eb-8c75-86447f3b4782.png)




#### MANDATORY GIF ####
![](https://media.giphy.com/media/hrRJ41JB2zlgZiYcCw/giphy-downsized-large.gif)
