### PR TITLE
amplify routes hack

### DIFF
--- a/src/components/Search/Search.js
+++ b/src/components/Search/Search.js
@@ -15,7 +15,7 @@ const Search = () => {
     let history = useHistory();
     const onFinish = (values) => {
         history.push({
-            pathname : '/results',
+            pathname : '/results/',
             search: `?proteinName=${values.protein}`,
             state: { proteinName: values.protein }
         });


### PR DESCRIPTION
#### JIRA LINK ####

- Amplify bug 😢  

There is a common issue on SPA when trying to work with routes. Essentially by using React Router we have javascript alter and control the url in the browser, so everytime a user does something our JS code looks at the history API and makes the appropriate changes. 

The problem is that when deploying to AWS (or anywhere really) if the user wants to directly access a given url say app.com/results?proteinName=PCSK9 our S3 does not really have anything in app.com/results and our JS has not been loaded yet to pick that up. 

Long story short, played around with redirects in AWS 

![](https://user-images.githubusercontent.com/30555119/116001653-4bd1dc00-a5aa-11eb-8304-474035adcfbb.png)

This redirect fixed the issue where all our routes where redirected straight to `/` instead to `/results?proteinName=PCSK9`

BUT the page is loosing the query params. And here is where AWS amplify comes in, apparently they do not currently support redirecting with query params (?) which is insane. You can read a lot of angry people here: https://github.com/aws-amplify/amplify-console/issues/97

Amplify team suggested a hack which is that query params are preserved if you have a leading slash at the end followed by the query params
`/results?proteinName=PCSK9` -> `/results/?proteinName=PCSK9`

Need to deploy this to be sure. 

**NOTE:  We might need this for every path that wants to leverage query params **

