### PR TITLE
add proteins list on upload

### DIFF
--- a/src/components/PatentUpload/PatentUpload.js
+++ b/src/components/PatentUpload/PatentUpload.js
@@ -1,5 +1,6 @@
 import { Component } from 'react';
 import { Storage } from 'aws-amplify';
+import { getProteinList, addProteinToList } from '../../utils/patentDataUtils';
 import awsExports from '../.././aws-exports';
 import './PatentUpload.css';
 
@@ -9,8 +10,15 @@ class PatentUpload extends Component {
         imageName: '',
         imageFile: '',
         response: '',
+        inputOptions: []
     };
 
+    componentDidMount() {
+        getProteinList()
+            .then((proteinList) => {
+                this.setState({ ...this.state, inputOptions: proteinList})
+            })
+    }
     uploadPatent = () => {
         /* First part of function checks user input to ensure it is not blank
       or include extraneous special characters*/
@@ -25,33 +33,37 @@ class PatentUpload extends Component {
             return false;
         }
         else {
+            const proteinName = document.getElementById('protein').value;
             /* If the input passes, iterate through all the files the user uploads
-      to the S3 bucket in a folder named public and then the protein name the user input
-      ex. s3bucket/public/PCSK9/1234.pdf */
-            for (var i =0; i < input.files.length; i++) {
-                Storage.put(`${document.getElementById('protein').value.toLowerCase()}/${input.files.item(i).name}`,
-                    this.upload.files,
+                to the S3 bucket in a folder named public and then the protein name the user input
+                ex. s3bucket/public/PCSK9/1234.pdf */
+            Promise.all(Array.from(input.files).map((file) => {
+                return Storage.put(`${proteinName.toLowerCase()}/${file.name}`,
+                    file,
                     {
                         bucket: 'psv-document-storage',
-                        contentType: input.files.item(i).type,
+                        contentType: file.type,
                         customPrefix: {
                             public: ''
                         }
-                    })
-                    .then(result => {
-                        this.upload = {
-                            bucket: awsExports.aws_user_files_s3_bucket,
-                            region: awsExports.aws_user_files_s3_bucket_region,
-                            key: 'public/' + this.upload.files.name
-                        }
-                        this.setState({ response: 'Success uploading file!' });
-                        alert('Success Uploading File! ');
-                        window.location.reload(true);
-                    })
-                    .catch(err => {
-                        this.setState({ response: `Error uploading file: ${err}` });
                     });
-            }
+            }))
+                .then(() => {
+                    return addProteinToList({ 
+                        proteinId: proteinName
+                    });
+                })
+                .then(() => {
+                    this.upload = {
+                        bucket: awsExports.aws_user_files_s3_bucket,
+                        region: awsExports.aws_user_files_s3_bucket_region,
+                        key: 'public/' + this.upload.files.name
+                    }
+                    this.setState({ response: 'Success uploading file!' });
+                    alert('Success Uploading File! ');
+                    window.location.reload(true);
+                })
+                .catch((err) => this.setState({ response: `Error uploading file: ${err}` }));
         }
     };
 
@@ -67,6 +79,9 @@ class PatentUpload extends Component {
     };
 
     render() {
+        const optionElements = this.state.inputOptions.map((protein) => {
+            return (<option key={`option-${protein.proteinId}`} value={protein.proteinId}></option>);
+        });
         return (
             <div className="App">
                 <h2>Please Upload Patents</h2>
@@ -80,11 +95,9 @@ class PatentUpload extends Component {
                     list="listProteins"
                 />
 
-                {/*List of proteins to be in the drop down */}
+                {/* List of proteins to be in the drop down */}
                 <datalist id = "listProteins">
-                    <option value = "PCSK9"></option>
-                    <option value = "COVID-19"></option>
-                    <option value = "WHEY"></option>
+                    {optionElements}
                 </datalist>
 
                 <div>
@@ -113,7 +126,7 @@ class PatentUpload extends Component {
                     <label className="toUploadLabel" for="toUploadLabel">Patents to be Upload: </label>
                     <div className="fileList" id="fileList" ref={ref => (this.fileList = ref)}></div>
                 </div>
-                <button className="uploadButton"onClick={this.uploadPatent}> Upload Files </button>
+                <button className="uploadButton" onClick={this.uploadPatent}> Upload Files </button>
 
                 {!!this.state.response && <div>{this.state.response}</div>}
             </div>

--- a/src/utils/patentDataUtils.js
+++ b/src/utils/patentDataUtils.js
@@ -29,6 +29,20 @@ function getProteinList() {
     return API.get(apiName, path, myInit);
 }
 
+function addProteinToList(proteinObj) {
+    /**
+     * Fetch patent details from the patents database for the given $proteinId
+     */
+    const apiName = 'proteinsAPI';
+    const path = '/proteins'; 
+    const myInit = { 
+        headers: {}, 
+        body: proteinObj,
+        response: false, // Only return response.data
+    };
+    return API.put(apiName, path, myInit);
+}
+
 function savePatentData(data){
     const apiName = 'patentsAPI';
     const path = '/patents';
@@ -129,6 +143,7 @@ function generateVisualizationDataset(patentData) {
 export {
     getPatentData,
     getProteinList,
+    addProteinToList,
     generateVisualizationDataset,
     savePatentData,
     sortDataset


### PR DESCRIPTION
#### JIRA LINK ####

https://patent-visualization.atlassian.net/browse/PSV-121

#### CHANGES ####

- We are making a request for available proteins that before where hardcoded
- We were iterating on the files and then making a promise for each upload but we were not waiting for all of them to end. Wrapped everything on a Promise.all and only after everything is done we show the success alert + we send the new protein name to the BE. 


Upload is broken before this change, did not work for me. There are a few parts of it that do not make a lot of sense to me. 
Like where do we use 

```
 this.upload = {
                            bucket: awsExports.aws_user_files_s3_bucket,
                            region: awsExports.aws_user_files_s3_bucket_region,
                            key: 'public/' + this.upload.files.name
                        }
```

And before we were using `this.upload.files` as second parameter for Storage.puts when we are iterating and we should me passing the file object one by one. (Unless we can pass an array of files directly to Storage.put and then we would not need to iterate. 


For testing I replaced Storage.put into promise.resolve() and logic for adding a new protein worked as expect. This needs some fine tuning like: 

- what happens if one file gets uploaded and another one fail. If Storage.put would allow bulk upload then we could fail all of them or pass all of them. But we need a story to fix all ov this.







#### MANDATORY GIF ####
![](https://media.giphy.com/media/ToMjGpIdDk9zrsnwgiQ/giphy.gif)
