### PR TITLE
Patent Upload case sensitive

### DIFF
--- a/src/components/PatentUpload/PatentUpload.js
+++ b/src/components/PatentUpload/PatentUpload.js
@@ -39,7 +39,8 @@ class PatentUpload extends Component {
                 ex. s3bucket/public/PCSK9/1234.pdf */
             
             Promise.all(Array.from(input.files).map((file) => {
-                var uploadResult = Storage.put(`${proteinName.toLowerCase()}/${file.name}`,
+                // IMPORTANT: We use the path from S3 to trigger the text mining process in ta repo
+                var uploadResult = Storage.put(`${proteinName}/${file.name}`,
                     file,
                     {
                         bucket: 'psv-document-storage',


### PR DESCRIPTION
#### JIRA LINK ####

- We were lowercasing the storage location that is the proteinId that `ta` uses and we need it to match with what the user used as protein name.

#### CHANGES ####

- Please list the relevant changes in the PR



#### DETAILS ####

- Any relevant details/references based on this changes





#### MANDATORY GIF ####

PR will **NOT** be aproved if no GIF is included 😄
Include small/social giphy inside the parens **()** https://giphy.com/
![]()
