### PR TITLE
details + fixing edit

### DIFF
--- a/src/components/PatentVisualizer/PatentTable.js
+++ b/src/components/PatentVisualizer/PatentTable.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import 'antd/dist/antd.css';
-import { Table, Modal, Checkbox, Button, Tooltip, Typography } from 'antd';
+import { Table, Modal, Checkbox, Button, Tooltip, Typography, List } from 'antd';
 import { InfoCircleOutlined } from '@ant-design/icons';
 import StringManager from '../../utils/StringManager';
 import { AMINO_THREE_LETTER_CODE } from '../../utils/aminoAcidTable';
@@ -131,8 +131,26 @@ const getColumns = (toggleShow, displayedPatents, onEditPatent) => [
                         <div key={`${mention.seqId}_${index}`}>
                             <Title level={5}>SEQ ID: {mention.seqId}</Title>
                             <p>{collapseResidueRanges(mention.claimedResidues, mention.value).filter((residue) => residue).join(', ')}</p>
+                            { mention.statements && mention.statements.length > 0 && 
+                                <Button type="link" style={{ padding: 0 }} onClick={() => {
+                                    Modal.info({
+                                        title: `Epitope Mentions: ${record.patentNumber}`,
+                                        content: (    
+                                            <List
+                                                dataSource={mention.statements}
+                                                renderItem={item => (
+                                                    <List.Item>
+                                                        {item}
+                                                    </List.Item>
+                                                )}
+                                            />)
+                                    });
+                                }}>
+                                    See mentions
+                                </Button>
+                            }
                         </div>
-                    )
+                    );
                 }
                 return null;
             })
@@ -150,8 +168,26 @@ const getColumns = (toggleShow, displayedPatents, onEditPatent) => [
                         <div key={`${mention.seqId}_${index}`}>
                             <Title level={5}>SEQ ID: {mention.seqId}</Title>
                             <p>{collapseResidueRanges(mention.claimedResidues, mention.value).filter((residue) => residue).join(', ')}</p>
+                            { mention.statements && mention.statements.length > 0 && 
+                                <Button type="link" style={{ padding: 0 }} onClick={() => {
+                                    Modal.info({
+                                        title: `Epitopes Claimed: ${record.patentNumber}`,
+                                        content: (    
+                                            <List
+                                                dataSource={mention.statements}
+                                                renderItem={item => (
+                                                    <List.Item>
+                                                        {item}
+                                                    </List.Item>
+                                                )}
+                                            />)
+                                    });
+                                }}>
+                                    See claims extracted
+                                </Button>
+                            }
                         </div>
-                    )
+                    );
                 }
                 return null;
             })

--- a/src/components/PatentVisualizer/PatentVisualizer.js
+++ b/src/components/PatentVisualizer/PatentVisualizer.js
@@ -345,7 +345,7 @@ const PatentVisualizer = props => {
     }
 
     const patentEditSubmit = (modifiedPatentDetails) => {
-        let pat = tableDetails.find(p => p.patentNumber === editPatentDetails.patentNumber);
+        let pat = _patentDetailRef.current.find(p => p.patentNumber === editPatentDetails.patentNumber);
         for (const property in modifiedPatentDetails) {
             pat[property] = modifiedPatentDetails[property];
         }
@@ -363,7 +363,7 @@ const PatentVisualizer = props => {
     }
 
     const onEditPatent = (patentNumber) => {
-        let pat = tableDetails.find(p => p.patentNumber === patentNumber);
+        let pat = _patentDetailRef.current.find(p => p.patentNumber === patentNumber);
         setEditPatentDetails(pat);        
         setModalShow(true);
     }


### PR DESCRIPTION
#### JIRA LINK ####


#### CHANGES ####

- Edit page was showing formatted data for the table instead of updating based off real data. Now residues to edit will be the original ones instead of the aligned ones. 
- When available user can see where the epitopes were extracted from (mentions and claims)

![](https://user-images.githubusercontent.com/30555119/117732002-eb46bf80-b1a3-11eb-846e-95af9226ecc5.png)





#### MANDATORY GIF ####
![](https://media.giphy.com/media/ZYR8rQwmdcWtUKkCNN/giphy.gif)
